### PR TITLE
Fix `WaitRecoveryDone` to actually wait for server to exit recovery

### DIFF
--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -639,16 +639,22 @@ func (p *PostgresKeeper) updatePGState(pctx context.Context) {
 //
 // Since postgres 9.6 (https://www.postgresql.org/docs/9.6/static/runtime-config-replication.html)
 // `synchronous_standby_names` can be in one of two formats:
-//   num_sync ( standby_name [, ...] )
-//   standby_name [, ...]
+//
+//	num_sync ( standby_name [, ...] )
+//	standby_name [, ...]
+//
 // two examples for this:
-//   2 (node1,node2)
-//   node1,node2
+//
+//	2 (node1,node2)
+//	node1,node2
+//
 // TODO(sgotti) since postgres 10 (https://www.postgresql.org/docs/10/static/runtime-config-replication.html)
 // `synchronous_standby_names` can be in one of three formats:
-//   [FIRST] num_sync ( standby_name [, ...] )
-//   ANY num_sync ( standby_name [, ...] )
-//   standby_name [, ...]
+//
+//	[FIRST] num_sync ( standby_name [, ...] )
+//	ANY num_sync ( standby_name [, ...] )
+//	standby_name [, ...]
+//
 // since we are writing ourself the synchronous_standby_names we don't handle this case.
 // If needed, to better handle all the cases with also a better validation of
 // standby names we could use something like the parser used by postgres


### PR DESCRIPTION
Waiting for the `recovery.signal` file to disappear is NOT the correct
way to determine if the server exited recovery or not, because the file
is removed shortly _before_ Postgres formally exits recovery mode.  So
with timings just right, Stolon would stop the server before recovery
was recorded as done, resulting in

    database system was shut down in recovery
    database system was not properly shut down; automatic recovery in progress

upon restarting the server.  In a trivial recovery (to the latest
consistent state) that wouldn't matter, but any and all of the
`recovery_target_` settings would effectively be ignored as Stolon then
restarts Postgres in normal non-recovery mode which replays WAL to the
end.

Fix this by doing what `pg_ctl -w` does: look at `postmaster.pid`'s
status line and wait for it to become `running`.
