### PR TITLE
Add `GetKeepersInfo(..., wait bool)`

### DIFF
--- a/cmd/sentinel/cmd/sentinel.go
+++ b/cmd/sentinel/cmd/sentinel.go
@@ -1881,7 +1881,7 @@ func (s *Sentinel) clusterSentinelCheck(pctx context.Context) {
 		return
 	}
 
-	keepersInfo, err := s.e.GetKeepersInfo(pctx)
+	keepersInfo, err := s.e.GetKeepersInfo(pctx, false)
 	if err != nil {
 		log.Errorw("cannot get keepers info", zap.Error(err))
 		return

--- a/internal/mock/store/store.go
+++ b/internal/mock/store/store.go
@@ -69,18 +69,18 @@ func (mr *MockStoreMockRecorder) GetClusterData(ctx interface{}) *gomock.Call {
 }
 
 // GetKeepersInfo mocks base method.
-func (m *MockStore) GetKeepersInfo(ctx context.Context) (cluster.KeepersInfo, error) {
+func (m *MockStore) GetKeepersInfo(ctx context.Context, wait bool) (cluster.KeepersInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetKeepersInfo", ctx)
+	ret := m.ctrl.Call(m, "GetKeepersInfo", ctx, wait)
 	ret0, _ := ret[0].(cluster.KeepersInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetKeepersInfo indicates an expected call of GetKeepersInfo.
-func (mr *MockStoreMockRecorder) GetKeepersInfo(ctx interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetKeepersInfo(ctx, wait interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKeepersInfo", reflect.TypeOf((*MockStore)(nil).GetKeepersInfo), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKeepersInfo", reflect.TypeOf((*MockStore)(nil).GetKeepersInfo), ctx, wait)
 }
 
 // GetProxiesInfo mocks base method.

--- a/internal/store/k8s.go
+++ b/internal/store/k8s.go
@@ -17,6 +17,7 @@ package store
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -252,7 +253,10 @@ func (s *KubeStore) SetKeeperInfo(ctx context.Context, id string, ms *cluster.Ke
 	return s.patchKubeStatusAnnotation(msj)
 }
 
-func (s *KubeStore) GetKeepersInfo(ctx context.Context) (cluster.KeepersInfo, error) {
+func (s *KubeStore) GetKeepersInfo(ctx context.Context, wait bool) (cluster.KeepersInfo, error) {
+	if wait {
+		return nil, errors.New("not implemented")
+	}
 	keepers := cluster.KeepersInfo{}
 
 	podsClient := s.client.CoreV1().Pods(s.namespace)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -36,7 +36,7 @@ type Store interface {
 	PutClusterData(ctx context.Context, cd *cluster.ClusterData) error
 	GetClusterData(ctx context.Context) (*cluster.ClusterData, *KVPair, error)
 	SetKeeperInfo(ctx context.Context, id string, ms *cluster.KeeperInfo, ttl time.Duration) error
-	GetKeepersInfo(ctx context.Context) (cluster.KeepersInfo, error)
+	GetKeepersInfo(ctx context.Context, wait bool) (cluster.KeepersInfo, error)
 	SetSentinelInfo(ctx context.Context, si *cluster.SentinelInfo, ttl time.Duration) error
 	GetSentinelsInfo(ctx context.Context) (cluster.SentinelsInfo, error)
 	SetProxyInfo(ctx context.Context, pi *cluster.ProxyInfo, ttl time.Duration) error


### PR DESCRIPTION
This allows us to block on `GetKeepersInfo(..., wait=True)` until keepers actually show up in Consul.