### PR TITLE
Fix `WaitRecoveryDone` to wait for server to exit recovery (take two)

### DIFF
--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -1287,8 +1287,7 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 					return
 				}
 				log.Infof("recovery completed")
-			}
-			if err = pgm.WaitReady(cd.Cluster.DefSpec().SyncTimeout.Duration); err != nil {
+			} else if err = pgm.WaitReady(cd.Cluster.DefSpec().SyncTimeout.Duration); err != nil {
 				log.Errorw("timeout waiting for instance to be ready", zap.Error(err))
 				return
 			}


### PR DESCRIPTION
The fix in #5 was incomplete, because Postgres writes `ready` to
`postmaster.pid` after the recovery is complete, but _before_ promoting
the server to primary, resulting in a "database system was shut down in
recovery" situation again.  Fix this by polling `pg_is_in_recovery()`
directly.
