### PR TITLE
CI: turn on debug

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,6 +81,7 @@ jobs:
           STCTL_BIN: ${{ github.workspace }}/bin/stolonctl
           CONSUL_BIN: /usr/bin/consul
           INTEGRATION: 1
+          DEBUG: 1
         run: |
           mkdir -p $TMPDIR
           chmod +x ./bin/*


### PR DESCRIPTION
Looks like Stolon integration test requires DEBUG=1. This fixes:

* `TestServerParameters`
* `TestWalLevel`