### PR TITLE
test: disable Consul grpc_tls in tests

### DIFF
--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1026,6 +1026,7 @@ func NewTestConsul(t *testing.T, dir string, a ...string) (*TestStore, error) {
 	if _, err := f.WriteString(fmt.Sprintf(`{
 		"ports": {
 			"dns": -1,
+			"grpc_tls": -1,
 			"http": %s,
 			"serf_lan": %s,
 			"serf_wan": %s,


### PR DESCRIPTION
This port is [enabled by default](https://github.com/hashicorp/consul/issues/14211) in newer Consul and it wasn't used by Stolon tests; but it breaks the tests requiring more than one Consul. Fixes tests:

* `TestFailoverStandbyCluster`
* `TestFailoverSyncReplStandbyCluster`
* `TestFailoverFailedStandbyCluster`
* `TestFailoverFailedSyncStandbyCluster`
* `TestFailoverTooMuchLagStandbyCluster`
* `TestOldMasterRestartStandbyCluster`
* `TestPartition1StandbyCluster`
* `TestMasterChangedAddressStandbyCluster`
* `TestForceFailStandbyCluster`
* `TestForceFailSyncReplStandbyCluster`
* `TestInitStandbyCluster`
* `TestPromoteStandbyCluster`
* `TestPromoteStandbyClusterArchiveRecovery`