### PR TITLE
Watch cluster data and start keeper waiting for it

### DIFF
--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -813,7 +813,8 @@ func (p *PostgresKeeper) Start(ctx context.Context) {
 
 	var err error
 	var cd *cluster.ClusterData
-	cd, _, err = p.e.GetClusterData(context.TODO())
+	log.Info("waiting for cluster data to appear")
+	cd, _, err = p.e.GetClusterData(ctx, true)
 	if err != nil {
 		log.Errorw("error retrieving cluster data", zap.Error(err))
 	} else if cd != nil {
@@ -1043,7 +1044,7 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 	e := p.e
 	pgm := p.pgm
 
-	cd, _, err := e.GetClusterData(pctx)
+	cd, _, err := e.GetClusterData(pctx, false)
 	if err != nil {
 		log.Errorw("error retrieving cluster data", zap.Error(err))
 		return

--- a/cmd/proxy/cmd/proxy.go
+++ b/cmd/proxy/cmd/proxy.go
@@ -188,7 +188,7 @@ func (c *ClusterChecker) SetProxyInfo(e store.Store, generation int64, proxyTime
 
 // Check reads the cluster data and applies the right pollon configuration.
 func (c *ClusterChecker) Check() error {
-	cd, _, err := c.e.GetClusterData(context.TODO())
+	cd, _, err := c.e.GetClusterData(context.TODO(), false)
 	if err != nil {
 		return fmt.Errorf("cannot get cluster data: %v", err)
 	}

--- a/cmd/sentinel/cmd/sentinel.go
+++ b/cmd/sentinel/cmd/sentinel.go
@@ -1858,7 +1858,7 @@ func (s *Sentinel) clusterSentinelCheck(pctx context.Context) bool {
 	defer s.updateMutex.Unlock()
 	e := s.e
 
-	cd, prevCDPair, err := e.GetClusterData(pctx)
+	cd, prevCDPair, err := e.GetClusterData(pctx, false)
 	if err != nil {
 		log.Errorw("error retrieving cluster data", zap.Error(err))
 		goto nextIteration

--- a/cmd/stolonctl/cmd/clusterdata.go
+++ b/cmd/stolonctl/cmd/clusterdata.go
@@ -99,7 +99,7 @@ func readClusterdata(cmd *cobra.Command, args []string) {
 }
 
 func isSafeToWriteClusterData(store store.Store) error {
-	if cd, _, err := store.GetClusterData(context.TODO()); err != nil {
+	if cd, _, err := store.GetClusterData(context.TODO(), false); err != nil {
 		return err
 	} else if cd != nil {
 		if !writeClusterdataOpts.forceYes {

--- a/cmd/stolonctl/cmd/clusterdata_test.go
+++ b/cmd/stolonctl/cmd/clusterdata_test.go
@@ -75,7 +75,7 @@ func TestWriteClusterdata(t *testing.T) {
 		reader := strings.NewReader("{}")
 		store := mock_store.NewMockStore(ctrl)
 
-		store.EXPECT().GetClusterData(gomock.Any()).Return(nil, nil, fmt.Errorf("Error in getting cluster data"))
+		store.EXPECT().GetClusterData(gomock.Any(), false).Return(nil, nil, fmt.Errorf("Error in getting cluster data"))
 
 		err := writeClusterdata(reader, store)
 
@@ -97,7 +97,7 @@ func TestWriteClusterdata(t *testing.T) {
 
 		reader := strings.NewReader("{}")
 		store := mock_store.NewMockStore(ctrl)
-		store.EXPECT().GetClusterData(gomock.Any()).Return(&cluster.ClusterData{}, nil, nil)
+		store.EXPECT().GetClusterData(gomock.Any(), false).Return(&cluster.ClusterData{}, nil, nil)
 
 		err := writeClusterdata(reader, store)
 
@@ -121,7 +121,7 @@ func TestWriteClusterdata(t *testing.T) {
 		reader := strings.NewReader("{}")
 		store := mock_store.NewMockStore(ctrl)
 		cd := &cluster.ClusterData{}
-		store.EXPECT().GetClusterData(gomock.Any()).Return(cd, nil, nil)
+		store.EXPECT().GetClusterData(gomock.Any(), false).Return(cd, nil, nil)
 		store.EXPECT().PutClusterData(gomock.Any(), cd).Return(fmt.Errorf("error while uploading the cluster data"))
 
 		err := writeClusterdata(reader, store)
@@ -146,7 +146,7 @@ func TestWriteClusterdata(t *testing.T) {
 		reader := strings.NewReader("{}")
 		store := mock_store.NewMockStore(ctrl)
 		cd := &cluster.ClusterData{}
-		store.EXPECT().GetClusterData(gomock.Any()).Return(cd, nil, nil)
+		store.EXPECT().GetClusterData(gomock.Any(), false).Return(cd, nil, nil)
 		store.EXPECT().PutClusterData(gomock.Any(), cd).Return(nil)
 
 		err := writeClusterdata(reader, store)

--- a/cmd/stolonctl/cmd/init.go
+++ b/cmd/stolonctl/cmd/init.go
@@ -80,7 +80,7 @@ func initCluster(cmd *cobra.Command, args []string) {
 		die("%v", err)
 	}
 
-	cd, _, err := e.GetClusterData(context.TODO())
+	cd, _, err := e.GetClusterData(context.TODO(), false)
 	if err != nil {
 		die("cannot get cluster data: %v", err)
 	}
@@ -101,7 +101,7 @@ func initCluster(cmd *cobra.Command, args []string) {
 		os.Exit(0)
 	}
 
-	_, _, err = e.GetClusterData(context.TODO())
+	_, _, err = e.GetClusterData(context.TODO(), false)
 	if err != nil {
 		die("cannot get cluster data: %v", err)
 	}

--- a/cmd/stolonctl/cmd/register/cluster.go
+++ b/cmd/stolonctl/cmd/register/cluster.go
@@ -33,7 +33,7 @@ type Cluster struct {
 
 // NewCluster returns an new instance of Cluster
 func NewCluster(name string, rCfg Config, store store.Store) (*Cluster, error) {
-	cd, _, err := store.GetClusterData(context.TODO())
+	cd, _, err := store.GetClusterData(context.TODO(), false)
 
 	if err != nil {
 		return nil, err

--- a/cmd/stolonctl/cmd/register/cluster_test.go
+++ b/cmd/stolonctl/cmd/register/cluster_test.go
@@ -29,7 +29,7 @@ func TestNewCluster(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockStore := mock_store.NewMockStore(ctrl)
-		mockStore.EXPECT().GetClusterData(gomock.Any()).Return(nil, nil, errors.New("unable to fetch cluster data"))
+		mockStore.EXPECT().GetClusterData(gomock.Any(), false).Return(nil, nil, errors.New("unable to fetch cluster data"))
 
 		_, err := NewCluster("test", Config{}, mockStore)
 
@@ -43,7 +43,7 @@ func TestNewCluster(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockStore := mock_store.NewMockStore(ctrl)
-		mockStore.EXPECT().GetClusterData(gomock.Any()).Return(nil, nil, nil)
+		mockStore.EXPECT().GetClusterData(gomock.Any(), false).Return(nil, nil, nil)
 
 		_, err := NewCluster("test", Config{}, mockStore)
 
@@ -58,7 +58,7 @@ func TestNewCluster(t *testing.T) {
 		cd := &cluster.ClusterData{}
 
 		mockStore := mock_store.NewMockStore(ctrl)
-		mockStore.EXPECT().GetClusterData(gomock.Any()).Return(cd, nil, nil)
+		mockStore.EXPECT().GetClusterData(gomock.Any(), false).Return(cd, nil, nil)
 
 		expected := Cluster{name: "test", cd: cd}
 

--- a/cmd/stolonctl/cmd/register_test.go
+++ b/cmd/stolonctl/cmd/register_test.go
@@ -89,7 +89,7 @@ func TestCheckAndRegisterMasterAndSlaves(t *testing.T) {
 			Cluster: &cluster.Cluster{},
 			DBs:     cluster.DBs{},
 		}
-		mockStore.EXPECT().GetClusterData(gomock.Any()).Return(&clusterData, &store.KVPair{}, nil)
+		mockStore.EXPECT().GetClusterData(gomock.Any(), false).Return(&clusterData, &store.KVPair{}, nil)
 		mockServiceDiscovery.EXPECT().DeRegister(&anotherServiceInfo)
 		mockServiceDiscovery.EXPECT().DeRegister(&serviceInfo)
 
@@ -122,7 +122,7 @@ func TestCheckAndRegisterMasterAndSlaves(t *testing.T) {
 				},
 			},
 		}
-		mockStore.EXPECT().GetClusterData(gomock.Any()).Return(&clusterData, &store.KVPair{}, nil)
+		mockStore.EXPECT().GetClusterData(gomock.Any(), false).Return(&clusterData, &store.KVPair{}, nil)
 		mockServiceDiscovery.EXPECT().Register(&serviceInfo)
 		mockServiceDiscovery.EXPECT().Register(&anotherServiceInfo)
 
@@ -156,7 +156,7 @@ func TestCheckAndRegisterMasterAndSlaves(t *testing.T) {
 				},
 			},
 		}
-		mockStore.EXPECT().GetClusterData(gomock.Any()).Return(&clusterData, &store.KVPair{}, nil)
+		mockStore.EXPECT().GetClusterData(gomock.Any(), false).Return(&clusterData, &store.KVPair{}, nil)
 		mockServiceDiscovery.EXPECT().DeRegister(&yetAnotherServiceInfo)
 
 		checkAndRegisterMasterAndSlaves(clusterName, mockStore, mockServiceDiscovery, false)
@@ -189,7 +189,7 @@ func TestCheckAndRegisterMasterAndSlaves(t *testing.T) {
 					},
 				},
 			}
-			mockStore.EXPECT().GetClusterData(gomock.Any()).Return(&clusterData, &store.KVPair{}, nil)
+			mockStore.EXPECT().GetClusterData(gomock.Any(), false).Return(&clusterData, &store.KVPair{}, nil)
 			mockServiceDiscovery.EXPECT().DeRegister(&masterServiceInfo)
 
 			checkAndRegisterMasterAndSlaves(clusterName, mockStore, mockServiceDiscovery, false)
@@ -216,7 +216,7 @@ func TestCheckAndRegisterMasterAndSlaves(t *testing.T) {
 					},
 				},
 			}
-			mockStore.EXPECT().GetClusterData(gomock.Any()).Return(&clusterData, &store.KVPair{}, nil)
+			mockStore.EXPECT().GetClusterData(gomock.Any(), false).Return(&clusterData, &store.KVPair{}, nil)
 			mockServiceDiscovery.EXPECT().DeRegister(&masterService)
 
 			checkAndRegisterMasterAndSlaves(clusterName, mockStore, mockServiceDiscovery, false)
@@ -242,7 +242,7 @@ func TestCheckAndRegisterMasterAndSlaves(t *testing.T) {
 					},
 				},
 			}
-			mockStore.EXPECT().GetClusterData(gomock.Any()).Return(&clusterData, &store.KVPair{}, nil)
+			mockStore.EXPECT().GetClusterData(gomock.Any(), false).Return(&clusterData, &store.KVPair{}, nil)
 
 			checkAndRegisterMasterAndSlaves(clusterName, mockStore, mockServiceDiscovery, false)
 		})
@@ -275,7 +275,7 @@ func TestCheckAndRegisterMasterAndSlaves(t *testing.T) {
 					},
 				},
 			}
-			mockStore.EXPECT().GetClusterData(gomock.Any()).Return(&clusterData, &store.KVPair{}, nil)
+			mockStore.EXPECT().GetClusterData(gomock.Any(), false).Return(&clusterData, &store.KVPair{}, nil)
 			mockServiceDiscovery.EXPECT().Register(&masterServiceInfo)
 
 			checkAndRegisterMasterAndSlaves(clusterName, mockStore, mockServiceDiscovery, true)
@@ -297,7 +297,7 @@ func TestCheckAndRegisterMasterAndSlaves(t *testing.T) {
 				Cluster: &cluster.Cluster{},
 				DBs:     cluster.DBs{},
 			}
-			mockStore.EXPECT().GetClusterData(gomock.Any()).Return(&clusterData, &store.KVPair{}, nil)
+			mockStore.EXPECT().GetClusterData(gomock.Any(), false).Return(&clusterData, &store.KVPair{}, nil)
 			mockServiceDiscovery.EXPECT().DeRegister(&masterService)
 
 			checkAndRegisterMasterAndSlaves(clusterName, mockStore, mockServiceDiscovery, true)
@@ -324,7 +324,7 @@ func TestCheckAndRegisterMasterAndSlaves(t *testing.T) {
 					},
 				},
 			}
-			mockStore.EXPECT().GetClusterData(gomock.Any()).Return(&clusterData, &store.KVPair{}, nil)
+			mockStore.EXPECT().GetClusterData(gomock.Any(), false).Return(&clusterData, &store.KVPair{}, nil)
 			mockServiceDiscovery.EXPECT().Register(&masterService)
 
 			checkAndRegisterMasterAndSlaves(clusterName, mockStore, mockServiceDiscovery, true)

--- a/cmd/stolonctl/cmd/stolonctl.go
+++ b/cmd/stolonctl/cmd/stolonctl.go
@@ -98,7 +98,7 @@ func die(format string, a ...interface{}) {
 }
 
 func getClusterData(e store.Store) (*cluster.ClusterData, *store.KVPair, error) {
-	cd, pair, err := e.GetClusterData(context.TODO())
+	cd, pair, err := e.GetClusterData(context.TODO(), false)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot get cluster data: %v", err)
 	}

--- a/internal/mock/store/store.go
+++ b/internal/mock/store/store.go
@@ -55,7 +55,7 @@ func (mr *MockStoreMockRecorder) AtomicPutClusterData(ctx, cd, previous interfac
 // GetClusterData mocks base method.
 func (m *MockStore) GetClusterData(ctx context.Context, wait bool) (*cluster.ClusterData, *store.KVPair, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterData", ctx)
+	ret := m.ctrl.Call(m, "GetClusterData", ctx, wait)
 	ret0, _ := ret[0].(*cluster.ClusterData)
 	ret1, _ := ret[1].(*store.KVPair)
 	ret2, _ := ret[2].(error)
@@ -63,9 +63,9 @@ func (m *MockStore) GetClusterData(ctx context.Context, wait bool) (*cluster.Clu
 }
 
 // GetClusterData indicates an expected call of GetClusterData.
-func (mr *MockStoreMockRecorder) GetClusterData(ctx interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetClusterData(ctx, wait interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterData", reflect.TypeOf((*MockStore)(nil).GetClusterData), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterData", reflect.TypeOf((*MockStore)(nil).GetClusterData), ctx, wait)
 }
 
 // GetKeepersInfo mocks base method.

--- a/internal/mock/store/store.go
+++ b/internal/mock/store/store.go
@@ -53,7 +53,7 @@ func (mr *MockStoreMockRecorder) AtomicPutClusterData(ctx, cd, previous interfac
 }
 
 // GetClusterData mocks base method.
-func (m *MockStore) GetClusterData(ctx context.Context) (*cluster.ClusterData, *store.KVPair, error) {
+func (m *MockStore) GetClusterData(ctx context.Context, wait bool) (*cluster.ClusterData, *store.KVPair, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetClusterData", ctx)
 	ret0, _ := ret[0].(*cluster.ClusterData)

--- a/internal/store/k8s.go
+++ b/internal/store/k8s.go
@@ -222,7 +222,7 @@ func (s *KubeStore) PutClusterData(ctx context.Context, cd *cluster.ClusterData)
 	return nil
 }
 
-func (s *KubeStore) GetClusterData(ctx context.Context) (*cluster.ClusterData, *KVPair, error) {
+func (s *KubeStore) GetClusterData(ctx context.Context, wait bool) (*cluster.ClusterData, *KVPair, error) {
 	epsClient := s.client.CoreV1().ConfigMaps(s.namespace)
 	result, err := epsClient.Get(s.resourceName, metav1.GetOptions{})
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -34,7 +34,7 @@ var (
 type Store interface {
 	AtomicPutClusterData(ctx context.Context, cd *cluster.ClusterData, previous *KVPair) (*KVPair, error)
 	PutClusterData(ctx context.Context, cd *cluster.ClusterData) error
-	GetClusterData(ctx context.Context) (*cluster.ClusterData, *KVPair, error)
+	GetClusterData(ctx context.Context, wait bool) (*cluster.ClusterData, *KVPair, error)
 	SetKeeperInfo(ctx context.Context, id string, ms *cluster.KeeperInfo, ttl time.Duration) error
 	GetKeepersInfo(ctx context.Context, wait bool) (cluster.KeepersInfo, error)
 	SetSentinelInfo(ctx context.Context, si *cluster.SentinelInfo, ttl time.Duration) error

--- a/tests/integration/config_test.go
+++ b/tests/integration/config_test.go
@@ -538,7 +538,7 @@ func TestAdditionalReplicationSlots(t *testing.T) {
 		t.Fatalf("unexpected err: %v", err)
 	}
 
-	cd, _, err := sm.GetClusterData(context.TODO())
+	cd, _, err := sm.GetClusterData(context.TODO(), false)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -835,7 +835,7 @@ func TestAdvertise(t *testing.T) {
 	}
 
 	// Check advertised listen address and port
-	cd, _, err := sm.GetClusterData(context.TODO())
+	cd, _, err := sm.GetClusterData(context.TODO(), false)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}

--- a/tests/integration/ha_test.go
+++ b/tests/integration/ha_test.go
@@ -1345,7 +1345,7 @@ func TestFailedStandby(t *testing.T) {
 		t.Fatalf("expected 2 DBs in cluster data: %v", err)
 	}
 
-	cd, _, err := sm.GetClusterData(context.TODO())
+	cd, _, err := sm.GetClusterData(context.TODO(), false)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -1647,7 +1647,7 @@ func testKeeperRemovalStolonCtl(t *testing.T, syncRepl bool) {
 	}
 
 	// get current stanbdys[0] db uid
-	cd, _, err := sm.GetClusterData(context.TODO())
+	cd, _, err := sm.GetClusterData(context.TODO(), false)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -1735,7 +1735,7 @@ func TestStandbyCantSync(t *testing.T) {
 	}
 
 	// get current stanbdys[0] db uid
-	cd, _, err := sm.GetClusterData(context.TODO())
+	cd, _, err := sm.GetClusterData(context.TODO(), false)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -1791,7 +1791,7 @@ func TestStandbyCantSync(t *testing.T) {
 	// check that the current stanbdys[0] db uid is different. This means the
 	// sentinel found that standbys[0] won't sync due to missing wals and asked
 	// the keeper to resync (defining e new db in the cluster data)
-	cd, _, err = sm.GetClusterData(context.TODO())
+	cd, _, err = sm.GetClusterData(context.TODO(), false)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}

--- a/tests/integration/init_test.go
+++ b/tests/integration/init_test.go
@@ -144,7 +144,7 @@ func testInitNew(t *testing.T, merge bool) {
 		t.Fatalf("unexpected err: %v", err)
 	}
 
-	cd, _, err := sm.GetClusterData(context.TODO())
+	cd, _, err := sm.GetClusterData(context.TODO(), false)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -286,7 +286,7 @@ func testInitExisting(t *testing.T, merge bool) {
 		t.Fatalf("expected archive_mode empty")
 	}
 
-	cd, _, err := sm.GetClusterData(context.TODO())
+	cd, _, err := sm.GetClusterData(context.TODO(), false)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -453,7 +453,7 @@ func TestInitialClusterSpec(t *testing.T) {
 		t.Fatal("expected cluster in initializing phase")
 	}
 
-	cd, _, err := sm.GetClusterData(context.TODO())
+	cd, _, err := sm.GetClusterData(context.TODO(), false)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}

--- a/tests/integration/sentinel_test.go
+++ b/tests/integration/sentinel_test.go
@@ -98,7 +98,7 @@ func TestSentinelEnabledProxies(t *testing.T) {
 	t.Logf("stopping sentinel")
 	ts.Stop()
 
-	cd, _, err := sm.GetClusterData(context.TODO())
+	cd, _, err := sm.GetClusterData(context.TODO(), false)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestSentinelEnabledProxies(t *testing.T) {
 	t.Logf("clusterdata changed")
 
 	// check that the enabled proxies aren't changed (same Proxy Generation and same EnabledProxies)
-	cd, _, err = sm.GetClusterData(context.TODO())
+	cd, _, err = sm.GetClusterData(context.TODO(), false)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1114,13 +1114,13 @@ func (ts *TestStore) WaitDown(timeout time.Duration) error {
 }
 
 func WaitClusterDataUpdated(e *store.KVBackedStore, timeout time.Duration) error {
-	icd, _, err := e.GetClusterData(context.TODO())
+	icd, _, err := e.GetClusterData(context.TODO(), false)
 	if err != nil {
 		return fmt.Errorf("unexpected err: %v", err)
 	}
 	start := time.Now()
 	for time.Now().Add(-timeout).Before(start) {
-		cd, _, err := e.GetClusterData(context.TODO())
+		cd, _, err := e.GetClusterData(context.TODO(), false)
 		if err != nil || cd == nil {
 			goto end
 		}
@@ -1136,7 +1136,7 @@ func WaitClusterDataUpdated(e *store.KVBackedStore, timeout time.Duration) error
 func WaitClusterDataWithMaster(e *store.KVBackedStore, timeout time.Duration) (string, error) {
 	start := time.Now()
 	for time.Now().Add(-timeout).Before(start) {
-		cd, _, err := e.GetClusterData(context.TODO())
+		cd, _, err := e.GetClusterData(context.TODO(), false)
 		if err != nil || cd == nil {
 			goto end
 		}
@@ -1152,7 +1152,7 @@ func WaitClusterDataWithMaster(e *store.KVBackedStore, timeout time.Duration) (s
 func WaitClusterDataMaster(master string, e *store.KVBackedStore, timeout time.Duration) error {
 	start := time.Now()
 	for time.Now().Add(-timeout).Before(start) {
-		cd, _, err := e.GetClusterData(context.TODO())
+		cd, _, err := e.GetClusterData(context.TODO(), false)
 		if err != nil || cd == nil {
 			goto end
 		}
@@ -1170,7 +1170,7 @@ func WaitClusterDataMaster(master string, e *store.KVBackedStore, timeout time.D
 func WaitClusterDataKeeperInitialized(keeperUID string, e *store.KVBackedStore, timeout time.Duration) error {
 	start := time.Now()
 	for time.Now().Add(-timeout).Before(start) {
-		cd, _, err := e.GetClusterData(context.TODO())
+		cd, _, err := e.GetClusterData(context.TODO(), false)
 		if err != nil || cd == nil {
 			goto end
 		}
@@ -1195,7 +1195,7 @@ func WaitClusterDataSynchronousStandbys(synchronousStandbys []string, e *store.K
 	sort.Strings(synchronousStandbys)
 	start := time.Now()
 	for time.Now().Add(-timeout).Before(start) {
-		cd, _, err := e.GetClusterData(context.TODO())
+		cd, _, err := e.GetClusterData(context.TODO(), false)
 		if err != nil || cd == nil {
 			goto end
 		}
@@ -1237,7 +1237,7 @@ func WaitClusterDataSynchronousStandbys(synchronousStandbys []string, e *store.K
 func WaitClusterPhase(e *store.KVBackedStore, phase cluster.ClusterPhase, timeout time.Duration) error {
 	start := time.Now()
 	for time.Now().Add(-timeout).Before(start) {
-		cd, _, err := e.GetClusterData(context.TODO())
+		cd, _, err := e.GetClusterData(context.TODO(), false)
 		if err != nil || cd == nil {
 			goto end
 		}
@@ -1253,7 +1253,7 @@ func WaitClusterPhase(e *store.KVBackedStore, phase cluster.ClusterPhase, timeou
 func WaitNumDBs(e *store.KVBackedStore, n int, timeout time.Duration) error {
 	start := time.Now()
 	for time.Now().Add(-timeout).Before(start) {
-		cd, _, err := e.GetClusterData(context.TODO())
+		cd, _, err := e.GetClusterData(context.TODO(), false)
 		if err != nil || cd == nil {
 			goto end
 		}
@@ -1269,7 +1269,7 @@ func WaitNumDBs(e *store.KVBackedStore, n int, timeout time.Duration) error {
 func WaitStandbyKeeper(e *store.KVBackedStore, keeperUID string, timeout time.Duration) error {
 	start := time.Now()
 	for time.Now().Add(-timeout).Before(start) {
-		cd, _, err := e.GetClusterData(context.TODO())
+		cd, _, err := e.GetClusterData(context.TODO(), false)
 		if err != nil || cd == nil {
 			goto end
 		}
@@ -1291,7 +1291,7 @@ func WaitStandbyKeeper(e *store.KVBackedStore, keeperUID string, timeout time.Du
 func WaitClusterDataKeepers(keepersUIDs []string, e *store.KVBackedStore, timeout time.Duration) error {
 	start := time.Now()
 	for time.Now().Add(-timeout).Before(start) {
-		cd, _, err := e.GetClusterData(context.TODO())
+		cd, _, err := e.GetClusterData(context.TODO(), false)
 		if err != nil || cd == nil {
 			goto end
 		}
@@ -1325,7 +1325,7 @@ func WaitClusterSyncedXLogPos(keepers []*TestKeeper, xLogPos uint64, e *store.KV
 	for time.Now().Add(-timeout).Before(start) {
 		c := 0
 		curXLogPos := uint64(0)
-		cd, _, err := e.GetClusterData(context.TODO())
+		cd, _, err := e.GetClusterData(context.TODO(), false)
 		if err != nil || cd == nil {
 			goto end
 		}
@@ -1364,7 +1364,7 @@ func WaitClusterDataEnabledProxiesNum(e *store.KVBackedStore, n int, timeout tim
 	// and check for them instead of relying only on the number of proxies
 	start := time.Now()
 	for time.Now().Add(-timeout).Before(start) {
-		cd, _, err := e.GetClusterData(context.TODO())
+		cd, _, err := e.GetClusterData(context.TODO(), false)
 		if err != nil || cd == nil {
 			goto end
 		}


### PR DESCRIPTION
Keepers cannot run without cluster data, so let's wait for it to appear at the keeper startup.

This added `wait bool` to `Store.GetClusterData()`.